### PR TITLE
Fixed ArrayList<> not defaulting to ArrayList<Float> (Java 7)

### DIFF
--- a/src/dlg/bridges/FTPartialOrderBridge.java
+++ b/src/dlg/bridges/FTPartialOrderBridge.java
@@ -186,7 +186,7 @@ public class FTPartialOrderBridge {
                             idx = features.size();
                             features.add(f);
                             featureParentSort.add(s);
-                            featureValues.add(new ArrayList<>());
+                            featureValues.add(new ArrayList<Float>());
                         }
                         float value = (float)((IntegerFeatureTerm)v).getValue();
                         if (!featureValues.get(idx).contains(value)) featureValues.get(idx).add(value);
@@ -207,7 +207,7 @@ public class FTPartialOrderBridge {
                             idx = features.size();
                             features.add(f);
                             featureParentSort.add(s);
-                            featureValues.add(new ArrayList<>());
+                            featureValues.add(new ArrayList<Float>());
                         }
                         float value = (float)((FloatFeatureTerm)v).getValue();
                         if (!featureValues.get(idx).contains(value)) featureValues.get(idx).add(value);


### PR DESCRIPTION
I do not know if that's specific to Java 7, but it refused to build on my machine
without these explicit type parameters annotations
